### PR TITLE
fix: hash each leaf

### DIFF
--- a/sources/market/primary_market.move
+++ b/sources/market/primary_market.move
@@ -1,5 +1,6 @@
 module ticketland::primary_market {
   use std::vector;
+  use std::hash::sha3_256;
   use sui::clock::{Self, Clock};
   use sui::coin::{Coin};
   use sui::tx_context::{TxContext, sender};
@@ -37,7 +38,7 @@ module ticketland::primary_market {
     vector::append(&mut p1, p2);
     vector::append(&mut p1, *p3);
 
-    p1
+    sha3_256(p1)
   }
 
   fun pre_purchase(

--- a/tests/utils/merkle_tree.move
+++ b/tests/utils/merkle_tree.move
@@ -115,9 +115,9 @@ module ticketland::merkle_tree_test {
         string::append(&mut seat_index, utf8(b"."));
         string::append(&mut seat_index, seat_name);
 
-        vector::push_back(&mut leaves, *bytes(&seat_index));
+        vector::push_back(&mut leaves, sha3_256(*bytes(&seat_index)));
       } else {
-        vector::push_back(&mut leaves, b"NULL");
+        vector::push_back(&mut leaves, sha3_256(b"NULL"));
       };
 
       i = i + 1;


### PR DESCRIPTION
# Fixes
- Hash leaves when passing them to the MerkleTree to match the existing implementations