### PR TITLE
Feat/operator purchase

### DIFF
--- a/sources/market/basic_sale.move
+++ b/sources/market/basic_sale.move
@@ -12,7 +12,7 @@ module ticketland::basic_sale {
   use ticketland::event::{get_event_creator};
   use ticketland::attendance::{Self, has_attended};
   use ticketland::market_utils::{has_enough_balance, split_payable_amount};
-  use ticketland::event_registry::{Config};
+  use ticketland::event_registry::Config;
   use ticketland::sale_type::{
     FixedPrice, Refundable, get_fixed_price_amount, get_refundable_price_amount
   };
@@ -92,6 +92,30 @@ module ticketland::basic_sale {
     );
 
     (cnt_id, price, fees)
+  }
+
+  public(friend) entry fun fixed_price_operator(
+    event: &Event,
+    ticket_type_index: u64,
+    ticket_name: String,
+    seat_index: u64,
+    seat_name: String,
+    ctx: &mut TxContext
+  ): address {
+    let ticket_type = get_ticket_type(event, ticket_type_index);
+
+    let cnt_id = ticket::mint_cnt(
+      get_event_id(event),
+      get_ticket_type_id(ticket_type),
+      ticket_name,
+      u64_to_str(seat_index),
+      seat_name,
+      none(),
+      0,
+      ctx,
+    );
+
+    cnt_id
   }
 
   public(friend) entry fun refundable<T>(

--- a/sources/market/basic_sale.move
+++ b/sources/market/basic_sale.move
@@ -57,6 +57,7 @@ module ticketland::basic_sale {
       seat_name,
       none(),
       paid,
+      sender(ctx),
       ctx,
     )
   }
@@ -88,6 +89,7 @@ module ticketland::basic_sale {
       seat_name,
       some(coin_type),
       price,
+      sender(ctx),
       ctx,
     );
 
@@ -100,6 +102,7 @@ module ticketland::basic_sale {
     ticket_name: String,
     seat_index: u64,
     seat_name: String,
+    buyer: address,
     ctx: &mut TxContext
   ): address {
     let ticket_type = get_ticket_type(event, ticket_type_index);
@@ -112,6 +115,7 @@ module ticketland::basic_sale {
       seat_name,
       none(),
       0,
+      buyer,
       ctx,
     );
 
@@ -143,6 +147,7 @@ module ticketland::basic_sale {
       seat_name,
       some(coin_type),
       price,
+      sender(ctx),
       ctx,
     );
 

--- a/sources/market/basic_sale.move
+++ b/sources/market/basic_sale.move
@@ -6,7 +6,7 @@ module ticketland::basic_sale {
   use sui::transfer::{transfer, public_transfer};
   use std::type_name;
   use sui::object::{Self, UID, delete};
-  use sui::coin::{Self, Coin, split};
+  use sui::coin::{Coin, split};
   use ticketland::ticket::{Self, CNT, get_cnt_id, get_cnt_owner};
   use ticketland::num_utils::{u64_to_str};
   use ticketland::event::{get_event_creator};
@@ -19,6 +19,9 @@ module ticketland::basic_sale {
   use ticketland::event::{
     Event, get_ticket_type, get_event_id, get_ticket_type_id, get_sale_type,
   };
+
+  #[test_only]
+  use sui::coin::{Self};
 
   friend ticketland::primary_market;
 

--- a/sources/market/primary_market.move
+++ b/sources/market/primary_market.move
@@ -166,6 +166,7 @@ module ticketland::primary_market {
       ticket_name,
       seat_index,
       seat_name,
+      buyer,
       ctx,
     );
     post_purchase(event, seat_index);

--- a/sources/market/secondary_market.move
+++ b/sources/market/secondary_market.move
@@ -178,10 +178,11 @@ module ticketland::secondary_market {
     config: &Config,
     ctx: &mut TxContext
   ) {
+    let seller = sender(ctx);
+    assert!(get_cnt_owner(cnt) == seller, E_ONLY_CNT_OWNER);
     assert!(offer.is_open, E_OFFER_CLOSED);
     assert!(offer.ticket_type_id == get_cnt_ticket_type_id(cnt), E_WRONG_TICKET_TYPE);
 
-    let seller = sender(ctx);
     let Offer {id: _, price, buyer, ticket_type_id: _, is_open:_} = offer;
     let amount = value(price);
     let (fees, payable_amount, protocol_fee_address) = split_payable_amount<T>(price, amount, config);

--- a/sources/ticket.move
+++ b/sources/ticket.move
@@ -258,6 +258,7 @@ module ticketland::ticket {
     seat_name: String,
     coin_type: Option<ascii::String>,
     paid: u64,
+    owner: address,
     ctx: &mut TxContext,
   ): address {
     let id = object::new(ctx);
@@ -265,7 +266,7 @@ module ticketland::ticket {
 
     let cnt = CNT {
       id,
-      owner: sender(ctx),
+      owner,
       event_id,
       ticket_type_id,
       name,


### PR DESCRIPTION
# Additions
- Add a `fixed_price_operator` function to be used for FIAT purchases