### PR TITLE
fix: accept coin type in operator purchase

### DIFF
--- a/sources/market/basic_sale.move
+++ b/sources/market/basic_sale.move
@@ -99,7 +99,7 @@ module ticketland::basic_sale {
     (cnt_id, price, fees)
   }
 
-  public(friend) entry fun fixed_price_operator(
+  public(friend) entry fun fixed_price_operator<T>(
     event: &Event,
     ticket_type_index: u64,
     ticket_name: String,
@@ -109,6 +109,8 @@ module ticketland::basic_sale {
     ctx: &mut TxContext
   ): address {
     let ticket_type = get_ticket_type(event, ticket_type_index);
+    let coin_type = type_name::into_string(type_name::get<T>());
+    let price = get_fixed_price_amount(get_sale_type<FixedPrice<T>>(event, ticket_type_index));
 
     let cnt_id = ticket::mint_cnt(
       get_event_id(event),
@@ -116,8 +118,8 @@ module ticketland::basic_sale {
       ticket_name,
       u64_to_str(seat_index),
       seat_name,
-      none(),
-      0,
+      some(coin_type),
+      price,
       buyer,
       ctx,
     );

--- a/sources/market/primary_market.move
+++ b/sources/market/primary_market.move
@@ -148,7 +148,7 @@ module ticketland::primary_market {
     });
   }
 
-  public entry fun fixed_price_operator(
+  public entry fun fixed_price_operator<T>(
     _op_cap: &OperatorCap,
     buyer: address,
     event: &mut Event,
@@ -161,7 +161,7 @@ module ticketland::primary_market {
     ctx: &mut TxContext
   ) {
     pre_purchase(event, ticket_type_index, seat_index, seat_name, proof, clock);
-    let cnt_id = basic_sale::fixed_price_operator(
+    let cnt_id = basic_sale::fixed_price_operator<T>(
       event,
       ticket_type_index,
       ticket_name,


### PR DESCRIPTION
# Fixes
- Accept coin type in operator purchase so the cnt can then be listed in the secondary market